### PR TITLE
Add ability to specify app name when creating a project

### DIFF
--- a/src/commands/new/generators/project/errors.js
+++ b/src/commands/new/generators/project/errors.js
@@ -5,6 +5,7 @@ module.exports = function error (params, utils) {
     let errors = {
       en: {
         project_found: 'Existing Begin app already found in this directory',
+        invalid_appname: `Invalid app name`,
         invalid_runtime: `Function runtime must be one of: ${backtickify(runtimes)}`,
       }
     }

--- a/src/commands/new/generators/project/index.js
+++ b/src/commands/new/generators/project/index.js
@@ -1,3 +1,5 @@
+let looseName = /^[a-z][a-zA-Z0-9-_]+$/
+
 module.exports = {
   name: 'project',
   description: 'Initialize a new project',
@@ -9,13 +11,19 @@ module.exports = {
     let invalid = inventory.inv._project.manifest
     if (invalid) return error('project_found')
 
+    // App name (optional)
+    let appName = args.n || args.name ? args.n || args.name  : 'begin-app'
+    if (!looseName.test(appName)) {
+      return error('invalid_appname')
+    }
+
     // Runtime (optional)
     let runtime = args.r || args.runtime
     if (runtime && !runtimes.includes(runtime?.toLowerCase())) {
       return error('invalid_runtime')
     }
 
-    let arc = `@app\nbegin-app\n`
+    let arc = `@app\n${appName}\n`
     if (runtime) arc += `\n@aws\nruntime ${runtime}\n`
 
     // Write the new Arc project manifest
@@ -32,6 +40,11 @@ module.exports = {
           header: 'New project parameters',
           items: [
             {
+              name: '-n, --name',
+              description: 'Project name, must be: [a-z0-9-_]',
+              optional: true,
+            },
+            {
               name: '-r, --runtime',
               description: `Runtime, one of: ${backtickify(runtimes)}`,
               optional: true,
@@ -42,6 +55,10 @@ module.exports = {
           {
             name: 'Create a new project (runs Node.js by default)',
             example: 'begin new project',
+          },
+          {
+            name: 'Create a new project with name',
+            example: 'begin new project -n my-app',
           },
           {
             name: 'Create a new project running Python',

--- a/test/integration/commands/new/app-test.js
+++ b/test/integration/commands/new/app-test.js
@@ -48,6 +48,40 @@ async function runTests (runType, t) {
     t.equal(r.code, 0, 'Exited 0')
   })
 
+  t.test(`${mode} new project - with app name`, async t => {
+    t.plan(19)
+    let cwd, i, lambda, r
+
+    cwd = newFolder(newAppDir)
+    r = await begin('new project --name test-app', cwd)
+    i = await getInv(t, cwd)
+    t.pass('Project is valid')
+    t.equal(i.inv._project.manifest, join(cwd, 'app.arc'), 'Wrote manifest to folder')
+    t.equal(i.inv.app, 'test-app', 'Correct app name')
+    t.equal(i.inv.lambdaSrcDirs.length, 1, 'Project has a single Lambda')
+    lambda = i.get.http('get /*')
+    t.ok(existsSync(lambda.handlerFile), 'Wrote Lambda handler')
+    t.ok(lambda.handlerFile.endsWith('.js'), 'Lambda handler is JavaScript')
+    t.notOk(r.stdout, 'Did not print to stdout')
+    t.notOk(r.stderr, 'Did not print to stderr')
+    t.equal(r.code, 0, 'Exited 0')
+
+    cwd = newFolder(newAppDir)
+    r = await begin('new project --name test-app-python --runtime python', cwd)
+    i = await getInv(t, cwd)
+    t.pass('Project is valid')
+    t.equal(i.inv._project.manifest, join(cwd, 'app.arc'), 'Wrote manifest to folder')
+    t.equal(i.inv.app, 'test-app-python', 'Correct app name')
+    t.equal(i.inv.lambdaSrcDirs.length, 1, 'Project has a single Lambda')
+    lambda = i.get.http('get /*')
+    t.equal(lambda.config.runtimeAlias, 'python', 'Lambda is configured with Python')
+    t.ok(existsSync(lambda.handlerFile), 'Wrote Lambda handler')
+    t.ok(lambda.handlerFile.endsWith('.py'), 'Lambda handler is Python')
+    t.notOk(r.stdout, 'Did not print to stdout')
+    t.notOk(r.stderr, 'Did not print to stderr')
+    t.equal(r.code, 0, 'Exited 0')
+  })
+
   t.test(`${mode} new app (errors)`, async t => {
     t.plan(4)
     let cwd, r


### PR DESCRIPTION
Adds a name parameter to creating a new project.

```
begin new project --name my-app
```

Signed-off-by: macdonst <simon.macdonald@gmail.com>