### PR TITLE
Add `--host` option to `begin dev` help

### DIFF
--- a/src/commands/dev/help.js
+++ b/src/commands/dev/help.js
@@ -6,6 +6,11 @@ module.exports = {
       header: 'Dev server options',
       items: [
         {
+          name: '--host',
+          description: `Configure the host the dev server will listen on`,
+          optional: true,
+        },
+        {
           name: '-p, --port',
           description: `Configure the dev server's HTTP port`,
           optional: true,


### PR DESCRIPTION
From Discord: https://discord.com/channels/1012099764713705472/1020389997276319766/1020389997276319766

`begin dev` supports the --host flag, but it isn't listed in the cli help.
