### PR TITLE
Staging config flag

### DIFF
--- a/src/commands/domains/list.js
+++ b/src/commands/domains/list.js
@@ -12,13 +12,13 @@ async function action (params) {
   let apps = await client.list({ token, _staging })
 
   let presentDate = (date) => (new Date(date)).toLocaleString()
-  let mark = c.gray('└──')
-  let arrow = c.cyan('└─→')
+  let mark = c.gray(' └──')
+  let arrow = c.cyan(' └─→')
   let output = []
   domains.forEach(({ domain, domainID, status, appLink, r53LastStatus, updatedAt }) => {
     if (status === states.PURCHASING) return
 
-    let domainLine = `${c.underline(c.cyan(domain))}`
+    let domainLine = c.underline(c.cyan(`https://${domain}`))
     if (verbose) domainLine += ` <${domainID}> ${c.bold(status)} [updated: ${presentDate(updatedAt)}]`
     output.push(domainLine)
 
@@ -29,18 +29,18 @@ async function action (params) {
 
       let linkLine = `${arrow} ${c.bold(c.green(theApp.name))}`
       if (verbose) linkLine += ` <${appID}>`
-      linkLine += ` → "${theEnv.name}"`
+      linkLine += `: "${theEnv.name}"`
       if (verbose) linkLine += ` <${envID}>`
       output.push(linkLine)
     }
     else if (status === states.REGISTERING) {
-      output.push(`${mark} ${c.bold(`Registration: ${r53LastStatus}`)}`)
+      output.push(`  ${mark} ${c.bold(`Registration: ${r53LastStatus}`)}`)
     }
     else if (status === states.ACTIVE) {
-      output.push(`${mark} ${c.bold('Available to link with "begin domains link"')}`)
+      output.push(`  ${mark} ${c.bold('Available to link with "begin domains link"')}`)
     }
     else if (status === states.LINKING) {
-      output.push(`${mark} ${c.bold('Linking to an app environment')}`)
+      output.push(`  ${mark} ${c.bold('Linking to an app environment')}`)
       if (verbose)
         output.push(`  ${mark} Last DNS check: ${c.bold(r53LastStatus)}`)
     }

--- a/src/commands/login/index.js
+++ b/src/commands/login/index.js
@@ -10,7 +10,7 @@ module.exports = {
 }
 
 async function action (params) {
-  let { appVersion, cliDir, clientIDs = {}, printer, staging } = params
+  let { appVersion, cliDir, clientIDs = {}, printer, args: { staging } } = params
   let { join } = require('path')
   let { existsSync, readFileSync } = require('fs')
   let writeFile = require('../../lib').writeFile(params)

--- a/src/commands/login/index.js
+++ b/src/commands/login/index.js
@@ -10,21 +10,22 @@ module.exports = {
 }
 
 async function action (params) {
-  let { appVersion, cliDir, clientIDs = {}, printer } = params
+  let { appVersion, cliDir, clientIDs = {}, printer, staging } = params
   let { join } = require('path')
   let { existsSync, readFileSync } = require('fs')
   let writeFile = require('../../lib').writeFile(params)
-  let configFile = join(cliDir, 'config.json')
+  let cliFilename = staging ? 'config-staging.json' : 'config.json'
+  let configPath = join(cliDir, cliFilename)
   let now = new Date().toISOString()
   let headers = { 'content-type': 'application/x-www-form-urlencoded' }
 
   let config
   function writeConfig () {
     if (!config) return
-    writeFile(configFile, JSON.stringify(config, null, 2))
+    writeFile(configPath, JSON.stringify(config, null, 2))
   }
 
-  if (!existsSync(configFile)) {
+  if (!existsSync(configPath)) {
     config = {
       '// Begin config': `you can edit this file, just be sure to keep your 'access_token' secret (if you have one)`,
       created: now,
@@ -34,7 +35,7 @@ async function action (params) {
     writeConfig()
   }
   else {
-    config = JSON.parse(readFileSync(configFile))
+    config = JSON.parse(readFileSync(configPath))
   }
   let { access_token, device_code, stagingAPI } = config
   let { __BEGIN_TEST_URL__ } = process.env

--- a/src/commands/login/index.js
+++ b/src/commands/login/index.js
@@ -10,11 +10,11 @@ module.exports = {
 }
 
 async function action (params) {
-  let { appVersion, cliDir, clientIDs = {}, printer, args: { staging } } = params
+  let { appVersion, cliDir, clientIDs = {}, printer, args } = params
   let { join } = require('path')
   let { existsSync, readFileSync } = require('fs')
   let writeFile = require('../../lib').writeFile(params)
-  let cliFilename = staging ? 'config-staging.json' : 'config.json'
+  let cliFilename = args?.staging ? 'config-staging.json' : 'config.json'
   let configPath = join(cliDir, cliFilename)
   let now = new Date().toISOString()
   let headers = { 'content-type': 'application/x-www-form-urlencoded' }

--- a/src/commands/logout/index.js
+++ b/src/commands/logout/index.js
@@ -10,7 +10,7 @@ module.exports = {
 }
 
 async function action (params) {
-  let { cliDir, clientIDs = {}, staging } = params
+  let { cliDir, clientIDs = {}, args: { staging } } = params
   let { join } = require('path')
   let { existsSync, readFileSync } = require('fs')
   let writeFile = require('../../lib').writeFile(params)

--- a/src/commands/logout/index.js
+++ b/src/commands/logout/index.js
@@ -10,17 +10,18 @@ module.exports = {
 }
 
 async function action (params) {
-  let { cliDir, clientIDs = {} } = params
+  let { cliDir, clientIDs = {}, staging } = params
   let { join } = require('path')
   let { existsSync, readFileSync } = require('fs')
   let writeFile = require('../../lib').writeFile(params)
-  let configFile = join(cliDir, 'config.json')
+  let cliFilename = staging ? 'config-staging.json' : 'config.json'
+  let configPath = join(cliDir, cliFilename)
 
-  if (!existsSync(configFile)) {
+  if (!existsSync(configPath)) {
     return Error('Config file not found, cannot log out of Begin session')
   }
 
-  let config = JSON.parse(readFileSync(configFile))
+  let config = JSON.parse(readFileSync(configPath))
   let { access_token, stagingAPI } = config
   let { __BEGIN_TEST_URL__ } = process.env
   let domain = __BEGIN_TEST_URL__
@@ -52,7 +53,7 @@ async function action (params) {
     config.modified = now
     delete config.access_token
     delete config.device_code
-    writeFile(configFile, JSON.stringify(config, null, 2))
+    writeFile(configPath, JSON.stringify(config, null, 2))
     return 'Successfully logged out!'
   }
   catch (err) {

--- a/src/commands/logout/index.js
+++ b/src/commands/logout/index.js
@@ -10,11 +10,11 @@ module.exports = {
 }
 
 async function action (params) {
-  let { cliDir, clientIDs = {}, args: { staging } } = params
+  let { cliDir, clientIDs = {}, args } = params
   let { join } = require('path')
   let { existsSync, readFileSync } = require('fs')
   let writeFile = require('../../lib').writeFile(params)
-  let cliFilename = staging ? 'config-staging.json' : 'config.json'
+  let cliFilename = args?.staging ? 'config-staging.json' : 'config.json'
   let configPath = join(cliDir, cliFilename)
 
   if (!existsSync(configPath)) {

--- a/src/commands/telemetry/index.js
+++ b/src/commands/telemetry/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   names: { en: [ 'telemetry' ] },
   action: (params) => {
-    let { appVersion, args, cliDir, args: { staging } } = params
-    let { disable, enable } = args
+    let { appVersion, args, cliDir, } = params
+    let { disable, enable, staging } = args
 
     let lib = require('../../lib')
     let { getConfig } = lib

--- a/src/commands/telemetry/index.js
+++ b/src/commands/telemetry/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   names: { en: [ 'telemetry' ] },
   action: (params) => {
-    let { appVersion, args, cliDir, staging } = params
+    let { appVersion, args, cliDir, args: { staging } } = params
     let { disable, enable } = args
 
     let lib = require('../../lib')

--- a/src/commands/telemetry/index.js
+++ b/src/commands/telemetry/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   names: { en: [ 'telemetry' ] },
   action: (params) => {
-    let { appVersion, args, cliDir } = params
+    let { appVersion, args, cliDir, staging } = params
     let { disable, enable } = args
 
     let lib = require('../../lib')
@@ -15,17 +15,18 @@ module.exports = {
     let on = c.white(c.bold('enabled'))
     let off = c.white(c.bold('disabled'))
 
-    let configFile = join(cliDir, 'config.json')
+    let cliFilename = staging ? 'config-staging.json' : 'config.json'
+    let configPath = join(cliDir, cliFilename)
     let config = getConfig(params)
     function maybeCreateConfigFile () {
-      if (!existsSync(configFile)) {
+      if (!existsSync(configPath)) {
         config = {
           '// Begin config': `you can edit this file, just be sure to keep your 'access_token' secret (if you have one)`,
           created: now,
           createdVer: appVersion,
           modified: now,
         }
-        writeFile(configFile, JSON.stringify(config, null, 2))
+        writeFile(configPath, JSON.stringify(config, null, 2))
       }
     }
 
@@ -34,14 +35,14 @@ module.exports = {
       maybeCreateConfigFile()
       config.collectBasicTelemetry = true
       config.modified = now
-      writeFile(configFile, JSON.stringify(config, null, 2))
+      writeFile(configPath, JSON.stringify(config, null, 2))
       message = `Basic CLI telemetry manually set to ${on}`
     }
     else if (disable) {
       maybeCreateConfigFile()
       config.collectBasicTelemetry = false
       config.modified = now
-      writeFile(configFile, JSON.stringify(config, null, 2))
+      writeFile(configPath, JSON.stringify(config, null, 2))
       message = `Basic CLI telemetry manually set to ${off}`
     }
     else {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -34,7 +34,7 @@ function getConfig (params, print = true) {
 
   let { existsSync, readFileSync } = require('fs')
   let { join } = require('path')
-  let { cliDir, printer, staging } = params
+  let { cliDir, printer, args: { staging } } = params
   let cliFilename = staging ? 'config-staging.json' : 'config.json'
   let configPath = join(cliDir, cliFilename)
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -34,8 +34,8 @@ function getConfig (params, print = true) {
 
   let { existsSync, readFileSync } = require('fs')
   let { join } = require('path')
-  let { cliDir, printer, args: { staging } } = params
-  let cliFilename = staging ? 'config-staging.json' : 'config.json'
+  let { cliDir, printer, args } = params
+  let cliFilename = args?.staging ? 'config-staging.json' : 'config.json'
   let configPath = join(cliDir, cliFilename)
 
   // Local config file wins over env vars

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,7 +9,7 @@ function checkManifest (inventory) {
   let { parse } = require('path')
   let { base, ext } = parse(inventory.inv._project.manifest)
   if (base !== '.arc' && ext !== '.arc') {
-    let message = `Begin CLI only supports app.arc and .arc project manifests`
+    let message = 'Begin CLI only supports app.arc and .arc project manifests'
     return Error(message)
   }
 }
@@ -27,15 +27,16 @@ function getConfig (params, print = true) {
   if (config && !params._refresh) return config
 
   function done (via) {
-    if (print && config.stagingAPI) printer(`Begin staging enabled`)
+    if (print && config.stagingAPI) printer('Begin staging enabled')
     if (print && config.access_token) printer.debug(`Using Begin token via ${via}`)
     return config
   }
 
   let { existsSync, readFileSync } = require('fs')
   let { join } = require('path')
-  let { cliDir, printer } = params
-  let configPath = join(cliDir, 'config.json')
+  let { cliDir, printer, staging } = params
+  let cliFilename = staging ? 'config-staging.json' : 'config.json'
+  let configPath = join(cliDir, cliFilename)
 
   // Local config file wins over env vars
   if (!existsSync(configPath)) {


### PR DESCRIPTION
just a convenience for Beginners that are swapping between staging and prod APIs

use `--staging` to load `~/.begin/config-staging.json` instead

there's probably a more elegant way that could add a `staging` key to `config.json` with different creds, but that's a bigger change. this was quick.

![image](https://user-images.githubusercontent.com/15697/230530500-52995801-c652-4d24-996e-c0e9c089b88d.png)
