### PR TITLE
appID can be optional when retrieving

### DIFF
--- a/src/commands/create/index.js
+++ b/src/commands/create/index.js
@@ -18,7 +18,8 @@ async function action (params) {
   let manifestErr = checkManifest(params.inventory)
   if (manifestErr) return manifestErr
 
-  let appID = getAppID(params.inventory, args)
+  let appIdRequired = false // this command can create a new app
+  let appID = getAppID(params.inventory, args, appIdRequired)
 
   // Pass along any specified environment IDs
   let env = args.env || args.e

--- a/src/commands/create/index.js
+++ b/src/commands/create/index.js
@@ -18,8 +18,13 @@ async function action (params) {
   let manifestErr = checkManifest(params.inventory)
   if (manifestErr) return manifestErr
 
-  let appIdRequired = false // this command can create a new app
-  let appID = getAppID(params.inventory, args, appIdRequired)
+  let appID
+  try {
+    appID = getAppID(params.inventory, args)
+  }
+  catch (error) {
+    appID = null
+  }
 
   // Pass along any specified environment IDs
   let env = args.env || args.e

--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -18,7 +18,8 @@ async function action (params) {
   let manifestErr = checkManifest(params.inventory)
   if (manifestErr) return manifestErr
 
-  let appID = getAppID(params.inventory, args)
+  let appIdRequired = false // this command can create a new app
+  let appID = getAppID(params.inventory, args, appIdRequired)
 
   // Pass along any specified environment IDs
   let env = args.env || args.e

--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -18,8 +18,13 @@ async function action (params) {
   let manifestErr = checkManifest(params.inventory)
   if (manifestErr) return manifestErr
 
-  let appIdRequired = false // this command can create a new app
-  let appID = getAppID(params.inventory, args, appIdRequired)
+  let appID
+  try {
+    appID = getAppID(params.inventory, args)
+  }
+  catch (error) {
+    appID = null
+  }
 
   // Pass along any specified environment IDs
   let env = args.env || args.e

--- a/src/commands/domains/index.js
+++ b/src/commands/domains/index.js
@@ -13,13 +13,6 @@ let aliases = {
   unalias: 'unlink',
 }
 let defaultCommand = 'list'
-let appIdRequired = {
-  list: false,
-  add: false,
-  remove: true,
-  link: true,
-  unlink: true,
-}
 let help = require('./help').bind({})
 
 async function action (params) {
@@ -40,7 +33,13 @@ async function action (params) {
 
     params.inventory = await _inventory()
 
-    let appID = getAppID(params.inventory, args, appIdRequired[subcommand])
+    let appID
+    try {
+      appID = getAppID(params.inventory, args)
+    }
+    catch (error) {
+      appID = null
+    }
     let env = args.env || args.e
     let domain = args.domain
 

--- a/src/commands/domains/index.js
+++ b/src/commands/domains/index.js
@@ -13,6 +13,13 @@ let aliases = {
   unalias: 'unlink',
 }
 let defaultCommand = 'list'
+let appIdRequired = {
+  list: false,
+  add: false,
+  remove: true,
+  link: true,
+  unlink: true,
+}
 let help = require('./help').bind({})
 
 async function action (params) {
@@ -33,7 +40,7 @@ async function action (params) {
 
     params.inventory = await _inventory()
 
-    let appID = getAppID(params.inventory, args)
+    let appID = getAppID(params.inventory, args, appIdRequired[subcommand])
     let env = args.env || args.e
     let domain = args.domain
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -15,7 +15,7 @@ function checkManifest (inventory) {
 }
 
 // See if the project manifest contains an app ID
-function getAppID (inventory, args) {
+function getAppID (inventory, args, required = true) {
   // First, prioritize args
   let appID = args.app || args.a
   // Then move on to the project manifest
@@ -25,7 +25,7 @@ function getAppID (inventory, args) {
   }
   // Account for possible unintended minimist arg errata
   appID = appID !== true && appID || undefined
-  if (!appID) {
+  if (required && !appID) {
     throw Error(`Please specify an appID or run this command from within your app's folder`)
   }
   return appID

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -15,7 +15,7 @@ function checkManifest (inventory) {
 }
 
 // See if the project manifest contains an app ID
-function getAppID (inventory, args, required = true) {
+function getAppID (inventory, args) {
   // First, prioritize args
   let appID = args.app || args.a
   // Then move on to the project manifest
@@ -25,7 +25,7 @@ function getAppID (inventory, args, required = true) {
   }
   // Account for possible unintended minimist arg errata
   appID = appID !== true && appID || undefined
-  if (required && !appID) {
+  if (!appID) {
     throw Error(`Please specify an appID or run this command from within your app's folder`)
   }
   return appID


### PR DESCRIPTION
These commands have been updated:
`begin create|deploy|(domains list|add)` invoke `getAppID()` but do not require a result
`create` and `deploy` already handle missing appID and let the user create a new Begin app
`domains` subcommands sometimes need appID but handle that in the subcommand

I checked all other references to `getAppID()` and all those commands (`tail|logs|env|etc` do want to throw when trying to find an ID)