### PR TITLE
Issue #169: Need documentation when using ! in an environment variable value

### DIFF
--- a/src/commands/env/create/index.js
+++ b/src/commands/env/create/index.js
@@ -26,7 +26,15 @@ module.exports = {
       examples: [
         {
           name: `Create a variable named 'FOO' in 'staging'`,
-          example: 'begin env create --env staging --name FOO --value bar',
+          example: `begin env create --env staging --name FOO --value "bar"`,
+        },
+        {
+          name: `Create a variable named 'FOO' in 'staging' with escaped special characters (Mac/Linux)`,
+          example: `begin env create --env staging --name FOO --value "bar\\!"`,
+        },
+        {
+          name: `Create a variable named 'FOO' in 'staging' with special characters (Windows)`,
+          example: `begin env create --env staging --name FOO --value "bar!"`,
         },
       ]
     }

--- a/src/commands/env/create/index.js
+++ b/src/commands/env/create/index.js
@@ -19,22 +19,22 @@ module.exports = {
           },
           {
             name: '-v, --value',
-            description: `Env variable value`,
+            description: 'Env variable value',
           },
         ],
       },
       examples: [
         {
-          name: `Create a variable named 'FOO' in 'staging'`,
-          example: `begin env create --env staging --name FOO --value "bar"`,
+          name: "Create a variable named 'FOO' in 'staging'",
+          example: 'begin env create --env staging --name FOO --value "bar"',
         },
         {
-          name: `Create a variable named 'FOO' in 'staging' with escaped special characters (Mac/Linux)`,
-          example: `begin env create --env staging --name FOO --value "bar\\!"`,
+          name: "Create a variable named 'FOO' in 'staging' with escaped special characters (Mac/Linux)",
+          example: 'begin env create --env staging --name FOO --value "bar\\!"',
         },
         {
-          name: `Create a variable named 'FOO' in 'staging' with special characters (Windows)`,
-          example: `begin env create --env staging --name FOO --value "bar!"`,
+          name: "Create a variable named 'FOO' in 'staging' with special characters (Windows)",
+          example: 'begin env create --env staging --name FOO --value "bar!"',
         },
       ]
     }


### PR DESCRIPTION
Updating the help docs for env create. When you use a special character like `!`, you run into some weird behaviour on Mac and Windows. Unfortunately, the behaviour is different. In both cases, you need to quote the variable value, but on MacOS, you need to escape it as well.