### PR TITLE
Issue #168: Need better error message when using invalid character wh…

### DIFF
--- a/src/commands/env/create/action.js
+++ b/src/commands/env/create/action.js
@@ -3,6 +3,7 @@ module.exports = async function action (params) {
   let { access_token: token, stagingAPI: _staging } = config
   let client = require('@begin/api')
   let error = require('../errors')(params)
+  let looseName = /^[a-zA-Z_][a-zA-Z0-9_]+$/
 
   // Environment (required)
   let env = args.env || args.e
@@ -20,6 +21,9 @@ module.exports = async function action (params) {
   let name = args.name || args.n || args.key || args.k
   if (!name || name === true) {
     return error('no_name')
+  }
+  if (!looseName.test(name) || name.length > 64) {
+    return error('invalid_varname')
   }
   name = name.toUpperCase()
 

--- a/src/commands/env/errors.js
+++ b/src/commands/env/errors.js
@@ -7,6 +7,7 @@ module.exports = function error (params) {
         no_appid: 'App ID not found, please run with -a or --appID',
         no_env: 'Environment ID not found, please run with -e or --envID',
         no_name: 'Variable name not found, please run with -n or --name',
+        invalid_varname: 'Environment variable names can consist of up to 64 characters. The name can contain upper and lowercase letters, numbers, and underscores (_), but it must start with a letter or underscore.',
         no_value: 'Variable value not found, please run with -v or --value',
         create_fail: 'Failed to create environment variable',
         destroy_fail: 'Failed to destroy environment variable',


### PR DESCRIPTION
…en creating an environment variable name

Doing some client-side validation to provide better error messages when devs try to create environment variables from the Begin CLI.

See: https://docs.aws.amazon.com/opsworks/latest/APIReference/API_EnvironmentVariable.html